### PR TITLE
スワイプ時キーボードが退出, datapickerの「今日」ボタン削除

### DIFF
--- a/TodaysToDo/TodaysToDo.xcodeproj/project.pbxproj
+++ b/TodaysToDo/TodaysToDo.xcodeproj/project.pbxproj
@@ -84,9 +84,9 @@
 		9100FADC22219BBD0077AA9B /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
-				9100FADD22219BBD0077AA9B /* ThirdViewController.swift */,
 				9100FADE22219BBD0077AA9B /* FirstViewController.swift */,
 				9100FADF22219BBD0077AA9B /* SecondViewController.swift */,
+				9100FADD22219BBD0077AA9B /* ThirdViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";

--- a/TodaysToDo/TodaysToDo/Base.lproj/Main.storyboard
+++ b/TodaysToDo/TodaysToDo/Base.lproj/Main.storyboard
@@ -42,17 +42,24 @@
                                     <constraint firstItem="3I0-ex-mJJ" firstAttribute="top" secondItem="Rmg-SM-zWn" secondAttribute="top" constant="32" id="txn-Mc-1bh"/>
                                 </constraints>
                             </view>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hik-l0-sgC">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hik-l0-sgC">
                                 <rect key="frame" x="16" y="108" width="343" height="510"/>
                                 <subviews>
-                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="jpe-0b-uOy">
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="jpe-0b-uOy">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="510"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="343" id="Uqt-XH-U5L"/>
+                                            <constraint firstAttribute="height" constant="510" id="zfK-lX-nPP"/>
+                                        </constraints>
                                     </tableView>
                                 </subviews>
                                 <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="jpe-0b-uOy" secondAttribute="bottom" id="5LP-uq-U3K"/>
+                                    <constraint firstItem="jpe-0b-uOy" firstAttribute="leading" secondItem="Hik-l0-sgC" secondAttribute="leading" id="KEd-n4-Def"/>
                                     <constraint firstAttribute="height" constant="510" id="MfJ-aG-89y"/>
+                                    <constraint firstAttribute="trailing" secondItem="jpe-0b-uOy" secondAttribute="trailing" id="N0G-5v-C11"/>
+                                    <constraint firstItem="jpe-0b-uOy" firstAttribute="top" secondItem="Hik-l0-sgC" secondAttribute="top" id="abe-C3-65B"/>
                                     <constraint firstAttribute="width" constant="343" id="ce2-9H-Obi"/>
                                 </constraints>
                             </scrollView>

--- a/TodaysToDo/TodaysToDo/Commons/DatePickerKeyboard.swift
+++ b/TodaysToDo/TodaysToDo/Commons/DatePickerKeyboard.swift
@@ -30,7 +30,6 @@ class DatePickerKeyboard: UITextField {
         
         // textFieldのtextに日付を表示する
         setText()
-        
         inputView = datePicker
         inputAccessoryView = createToolbar()
     }
@@ -43,10 +42,9 @@ class DatePickerKeyboard: UITextField {
         let space = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: self, action: nil)
         space.width = 12
         let flexSpaceItem = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
-        let todayButtonItem = UIBarButtonItem(title: "今", style: .done, target: self, action: #selector(todayPicker))
         let doneButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(donePicker))
         
-        let toolbarItems = [flexSpaceItem, todayButtonItem, doneButtonItem, space]
+        let toolbarItems = [flexSpaceItem, doneButtonItem, space]
         
         toolbar.setItems(toolbarItems, animated: true)
         
@@ -56,11 +54,6 @@ class DatePickerKeyboard: UITextField {
     // キーボードの完了ボタンタップ時に呼ばれる
     @objc private func donePicker() {
         resignFirstResponder()
-    }
-    // キーボードの今日ボタンタップ時に呼ばれる
-    @objc private func todayPicker() {
-        datePicker.date = Date()
-        setText()
     }
     
     // datePickerの日付をtextFieldのtextに反映させる

--- a/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
+++ b/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
@@ -41,6 +41,9 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         todoListTableView.delegate = self
         todoListTableView.dataSource = self
         
+        // tableViewをスワイプ時、keyboardを下げる
+        todoListTableView.keyboardDismissMode = .onDrag
+        
         // Buttonにジェスチャーを追加
         let tapButton: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(addToDo(_:)))
         self.addButton.isUserInteractionEnabled = true
@@ -187,7 +190,6 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         todoTextField.text = ""
         view.endEditing(true)
         showKeyboardButton.isEnabled = true
-        selectKeyboard = 0
     }
     
     // キーボードのフレーム変化時の処理
@@ -219,6 +221,7 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         //submitFormのbottomの制約を元に戻す
         self.submitFormBottom.constant = -submitFormY
         self.view.layoutIfNeeded()
+        selectKeyboard = 0
     }
 
 


### PR DESCRIPTION
## 概要
* Input画面でスワイプ時、キーボードを下ろす処理の追加
* DataPickerのtoolBarから「今日」ボタンを削除

## 技術的変更点概要
* [TableView].keyboardDismissMode = .onDragにより、対象のViewをスワイプした時キーボードが下がるようにした。
* DataPickerクラスから対象のコードを削除

## 参考URL

## 備考