### PR TITLE
開始日時の設定機能の実装&DBのマイグレーション

### DIFF
--- a/TodaysToDo/Podfile.lock
+++ b/TodaysToDo/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Realm (3.13.1):
-    - Realm/Headers (= 3.13.1)
-  - Realm/Headers (3.13.1)
-  - RealmSwift (3.13.1):
-    - Realm (= 3.13.1)
+  - Realm (3.14.1):
+    - Realm/Headers (= 3.14.1)
+  - Realm/Headers (3.14.1)
+  - RealmSwift (3.14.1):
+    - Realm (= 3.14.1)
 
 DEPENDENCIES:
   - RealmSwift
@@ -14,8 +14,8 @@ SPEC REPOS:
     - RealmSwift
 
 SPEC CHECKSUMS:
-  Realm: 50071da38fe079e0735e47c9f2eae738c68c5996
-  RealmSwift: 8a1e6a02b7a08cd17a31e3115143fb69fe5f3fb9
+  Realm: e12c9c2387d05c5bba3a9c394838f5870e85763b
+  RealmSwift: a82eab9b04c3e1616082c7e17aa300740847769c
 
 PODFILE CHECKSUM: dd1f34f9268cccf31ff0561103025f5ca5305f19
 

--- a/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
+++ b/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
@@ -226,9 +226,13 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
     @objc func setStartDateTime(_ sender: UIButton) {
         
         // ボタンが押されたcellを特定
-        let cell = sender.superview?.superview?.superview?.superview as! ToDoListTableViewCell
+        guard let cell = sender.superview?.superview?.superview?.superview as? ToDoListTableViewCell else {
+            return
+        }
         // cellのindex番号を取得
-        let row = todoListTableView.indexPath(for: cell)?.row
+        guard let row = todoListTableView.indexPath(for: cell)?.row else {
+            return
+        }
         // Dateのフォーマットを設定
         let f = DateFormatter()
         f.dateStyle = .long
@@ -240,7 +244,7 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         do {
             let realm = try Realm()
             try realm.write {
-                self.todoList[row!].startDateTime = startDateTime
+                self.todoList[row].startDateTime = startDateTime
             }
         } catch {
         }

--- a/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
+++ b/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
@@ -52,7 +52,6 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         // Realmからデータを取得
         do {
             let realm = try Realm()
-            print(Realm.Configuration.defaultConfiguration.fileURL!)
             let predicate = NSPredicate(format: "startDateTime = nil")
             todoList = realm.objects(ToDo.self).filter(predicate)
         } catch {

--- a/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
+++ b/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
@@ -52,7 +52,7 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         // Realmからデータを取得
         do {
             let realm = try Realm()
-            let predicate = NSPredicate(format: "startDateTime = ''")
+            let predicate = NSPredicate(format: "startDateTime = nil")
             todoList = realm.objects(ToDo.self).filter(predicate)
         } catch {
         }
@@ -233,18 +233,12 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         guard let row = todoListTableView.indexPath(for: cell)?.row else {
             return
         }
-        // Dateのフォーマットを設定
-        let f = DateFormatter()
-        f.dateStyle = .long
-        f.timeStyle = .short
-        f.locale = Locale(identifier: "ja")
-        let startDateTime = f.string(from: cell.startDateTime.getDate())
         
         // Realm内にstartDateを設定
         do {
             let realm = try Realm()
             try realm.write {
-                self.todoList[row].startDateTime = startDateTime
+                self.todoList[row].startDateTime = cell.startDateTime.getDate()
             }
         } catch {
         }

--- a/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
+++ b/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
@@ -122,7 +122,6 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
     
     // セル内容の設定
     func setCellContents(_ cell: ToDoListTableViewCell, _ toDoTitle: UILabel) {
-        print("テスト")
         guard let row = todoListTableView.indexPath(for: cell)?.row else {
             return
         }

--- a/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
+++ b/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
@@ -52,7 +52,6 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         // Realmからデータを取得
         do{
             let realm = try Realm()
-            print(Realm.Configuration.defaultConfiguration.fileURL!)
             let predicate = NSPredicate(format: "startDateTime = ''")
             todoList = realm.objects(ToDo.self).filter(predicate)
         }catch{

--- a/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
+++ b/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
@@ -52,6 +52,7 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         // Realmからデータを取得
         do {
             let realm = try Realm()
+            print(Realm.Configuration.defaultConfiguration.fileURL!)
             let predicate = NSPredicate(format: "startDateTime = nil")
             todoList = realm.objects(ToDo.self).filter(predicate)
         } catch {
@@ -95,7 +96,8 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
     // セルの内容
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = todoListTableView.dequeueReusableCell(withIdentifier: "ToDoListTableViewCell", for: indexPath) as! ToDoListTableViewCell
-        cell.toDoListTableViewCellDelegate = self
+        // TableviewCellDelegateをselfで受け取る設定をし、ToDoのデータを渡す。
+        cell.configure(with: todoList[indexPath.row], delegate: self)
         
         return cell
     }
@@ -118,14 +120,6 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
     // セルの高さを設定
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return cellHeigh
-    }
-    
-    // セル内容の設定
-    func setCellContents(_ cell: ToDoListTableViewCell, _ toDoTitle: UILabel) {
-        guard let row = todoListTableView.indexPath(for: cell)?.row else {
-            return
-        }
-        toDoTitle.text = todoList[row].todo
     }
     
     // ToDoの追加および変更

--- a/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
+++ b/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
@@ -52,7 +52,8 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         // Realmからデータを取得
         do{
             let realm = try Realm()
-            let predicate = NSPredicate(format: "startDate = ''")
+            print(Realm.Configuration.defaultConfiguration.fileURL!)
+            let predicate = NSPredicate(format: "startDateTime = ''")
             todoList = realm.objects(ToDo.self).filter(predicate)
         }catch{
         }
@@ -104,6 +105,10 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         // カスタムセル内のプロパティ設定
         cell.todoText.text = todoList[indexPath.row].todo
         cell.todoText.adjustsFontSizeToFitWidth = true
+        
+        // セルの「設定」ボタン
+        cell.setStartDateTime.addTarget(self, action: #selector(setStartDateTime(_:)), for: .touchUpInside)
+        
         return cell
     }
     
@@ -216,5 +221,31 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         })
         showKeyboardButton.isEnabled = true
         selectKeyboard = 0
+    }
+    
+    // レコードに日付を設定する
+    @objc func setStartDateTime(_ sender: UIButton) {
+        
+        // ボタンが押されたcellを特定
+        let cell = sender.superview?.superview?.superview?.superview as! ToDoListTableViewCell
+        // cellのindex番号を取得
+        let row = todoListTableView.indexPath(for: cell)?.row
+        // Dateのフォーマットを設定
+        let f = DateFormatter()
+        f.dateStyle = .long
+        f.timeStyle = .short
+        f.locale = Locale(identifier: "ja")
+        let startDateTime = f.string(from: cell.startDateTime.getDate())
+        
+        // Realm内にstartDateを設定
+        do{
+            let realm = try Realm()
+            try realm.write {
+                self.todoList[row!].startDateTime = startDateTime
+            }
+        }catch{
+        }
+        
+        todoListTableView.reloadData()
     }
 }

--- a/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
+++ b/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
@@ -114,6 +114,10 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
             } catch {
             }
         }
+        // ToDoの編集中に編集対象のタスクを削除するとエラーになる
+        // そのため、削除した際は、キーボードを下げる処理を実装
+        todoTextField.text = ""
+        view.endEditing(true)
     }
     
     // セルの高さを設定
@@ -126,7 +130,7 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         if todoTextField.text != ""  {
             if addButton.titleLabel?.text == "追加" {
                 let newToDo = ToDo()
-                newToDo.todo = todoTextField.text!
+                newToDo.title = todoTextField.text!
                 
                 do {
                     let realm = try Realm()
@@ -141,7 +145,7 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
                 do {
                     let realm = try Realm()
                     try realm.write {
-                        self.todoList[cellIndex].todo = todoTextField.text!
+                        self.todoList[cellIndex].title = todoTextField.text!
                     }
                 } catch {
                 }
@@ -159,7 +163,7 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
             return
         }
         cellIndex = row
-        todoTextField.text = todoList[row].todo
+        todoTextField.text = todoList[row].title
         addButton.setTitle("変更", for: .normal)
         selectKeyboard = 1
         todoTextField.becomeFirstResponder()

--- a/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
+++ b/TodaysToDo/TodaysToDo/Controllers/FirstViewController.swift
@@ -50,11 +50,11 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         self.addButton.addGestureRecognizer(tapButton)
         
         // Realmからデータを取得
-        do{
+        do {
             let realm = try Realm()
             let predicate = NSPredicate(format: "startDateTime = ''")
             todoList = realm.objects(ToDo.self).filter(predicate)
-        }catch{
+        } catch {
         }
         // tableViewにカスタムセルを登録
         todoListTableView.register(UINib(nibName: "ToDoListTableViewCell", bundle: nil), forCellReuseIdentifier: "ToDoListTableViewCell")
@@ -115,13 +115,13 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath){
         if(editingStyle == UITableViewCell.EditingStyle.delete) {
             // Realm内のデータを削除
-            do{
+            do {
                 let realm = try Realm()
                 try realm.write {
                     realm.delete(self.todoList[indexPath.row])
                 }
                 tableView.deleteRows(at: [indexPath], with: UITableView.RowAnimation.fade)
-            }catch{
+            } catch {
             }
         }
     }
@@ -138,22 +138,22 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
                 let newToDo = ToDo()
                 newToDo.todo = todoTextField.text!
                 
-                do{
+                do {
                     let realm = try Realm()
                     try realm.write({ () -> Void in
                         realm.add(newToDo)
                     })
-                }catch{
+                } catch {
                 }
                 todoTextField.text = ""
             } else {
                 // Realm内のデータを編集
-                do{
+                do {
                     let realm = try Realm()
                     try realm.write {
                         self.todoList[cellIndex].todo = todoTextField.text!
                     }
-                }catch{
+                } catch {
                 }
                 todoTextField.text = ""
                 view.endEditing(true)
@@ -237,12 +237,12 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
         let startDateTime = f.string(from: cell.startDateTime.getDate())
         
         // Realm内にstartDateを設定
-        do{
+        do {
             let realm = try Realm()
             try realm.write {
                 self.todoList[row!].startDateTime = startDateTime
             }
-        }catch{
+        } catch {
         }
         
         todoListTableView.reloadData()

--- a/TodaysToDo/TodaysToDo/Models/ToDo.swift
+++ b/TodaysToDo/TodaysToDo/Models/ToDo.swift
@@ -13,9 +13,9 @@ class ToDo: Object {
     // todo
     @objc dynamic var todo = ""
     // 開始日時
-    @objc dynamic var startDate = ""
+    @objc dynamic var startDateTime = ""
     // 追加日時
     @objc dynamic var addDate = ""
     // 実行済み
-    @objc dynamic var done = true
+    @objc dynamic var done = false
 }

--- a/TodaysToDo/TodaysToDo/Models/ToDo.swift
+++ b/TodaysToDo/TodaysToDo/Models/ToDo.swift
@@ -13,7 +13,7 @@ class ToDo: Object {
     // todo
     @objc dynamic var todo = ""
     // 開始日時
-    @objc dynamic var startDateTime = ""
+    @objc dynamic var startDateTime: Date? = nil
     // 追加日時
     @objc dynamic var addDate = ""
     // 実行済み

--- a/TodaysToDo/TodaysToDo/Models/ToDo.swift
+++ b/TodaysToDo/TodaysToDo/Models/ToDo.swift
@@ -10,10 +10,10 @@ import Foundation
 import RealmSwift
 
 class ToDo: Object {
-    // todo
-    @objc dynamic var todo = ""
+    // todoのタイトル
+    @objc dynamic var title = ""
     // 開始日時
-    @objc dynamic var startDateTime: Date? = nil
+    @objc dynamic var startDateTime: Date?
     // 追加日時
     @objc dynamic var addDate = ""
     // 実行済み

--- a/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.swift
+++ b/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.swift
@@ -38,7 +38,7 @@ class ToDoListTableViewCell: UITableViewCell {
         self.todo = todo
         
         // ToDoのタイトルのtextを設定する
-        toDoTitle.text = todo.todo
+        toDoTitle.text = todo.title
         // ToDoのタイトルの文字の大きさを幅に合わせるように設定する
         toDoTitle.adjustsFontSizeToFitWidth = true
         // ToDoのタイトルをタップ可能に設定する。

--- a/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.swift
+++ b/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.swift
@@ -9,8 +9,6 @@
 import UIKit
 
 protocol ToDoListTableViewCellDelegate {
-    // セル内容の設定
-    func setCellContents(_ cell: ToDoListTableViewCell, _ toDoTitle: UILabel)
     // タスクの名前をタップした時の処理
     func didTappedToDoTitle(_ cell: ToDoListTableViewCell)
     // 「設定」ボタンタップ時の処理
@@ -21,20 +19,8 @@ class ToDoListTableViewCell: UITableViewCell {
 
     @IBOutlet weak private var toDoTitle: UILabel!
     @IBOutlet weak private var startDateTime: DatePickerKeyboard!
-    var toDoListTableViewCellDelegate: ToDoListTableViewCellDelegate?{
-        didSet {
-            toDoTitle.adjustsFontSizeToFitWidth = true
-            toDoTitle.isUserInteractionEnabled = true
-            self.toDoListTableViewCellDelegate?.setCellContents(self, toDoTitle)
-        }
-    }
-    
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        
-        let tapToDoTitleGesture: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.tapToDoTitle(_:)))
-        toDoTitle.addGestureRecognizer(tapToDoTitleGesture)
-    }
+    private var todo: ToDo?
+    private var toDoListTableViewCellDelegate: ToDoListTableViewCellDelegate?
     
     @objc func tapToDoTitle(_ sender: UITapGestureRecognizer) {
         self.toDoListTableViewCellDelegate?.didTappedToDoTitle(self)
@@ -42,5 +28,25 @@ class ToDoListTableViewCell: UITableViewCell {
     
     @IBAction func tapStartDateTimeButton(_ sender: UIButton) {
         self.toDoListTableViewCellDelegate?.didTappedStartDateTimeButton(self, startDateTime)
+    }
+    
+    // Cellをインスタンス化した時に行うCellに対する設定メソッド
+    func configure(with todo: ToDo, delegate: ToDoListTableViewCellDelegate) {
+        // 引数delegateに処理をDelegateする設定をする
+        toDoListTableViewCellDelegate = delegate
+        // セルのToDoデータをcellのインスタンスに保持する
+        self.todo = todo
+        
+        // ToDoのタイトルのtextを設定する
+        toDoTitle.text = todo.todo
+        // ToDoのタイトルの文字の大きさを幅に合わせるように設定する
+        toDoTitle.adjustsFontSizeToFitWidth = true
+        // ToDoのタイトルをタップ可能に設定する。
+        toDoTitle.isUserInteractionEnabled = true
+        
+        // タップした時の処理を設定する
+        let tapToDoTitleGesture: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.tapToDoTitle(_:)))
+        // ToDoのタイトルに設定したGestureを設定する
+        toDoTitle.addGestureRecognizer(tapToDoTitleGesture)
     }
 }

--- a/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.swift
+++ b/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.swift
@@ -21,16 +21,19 @@ class ToDoListTableViewCell: UITableViewCell {
 
     @IBOutlet weak private var toDoTitle: UILabel!
     @IBOutlet weak private var startDateTime: DatePickerKeyboard!
-    var toDoListTableViewCellDelegate: ToDoListTableViewCellDelegate?
+    var toDoListTableViewCellDelegate: ToDoListTableViewCellDelegate?{
+        didSet {
+            toDoTitle.adjustsFontSizeToFitWidth = true
+            toDoTitle.isUserInteractionEnabled = true
+            self.toDoListTableViewCellDelegate?.setCellContents(self, toDoTitle)
+        }
+    }
     
     override func awakeFromNib() {
         super.awakeFromNib()
         
         let tapToDoTitleGesture: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.tapToDoTitle(_:)))
         toDoTitle.addGestureRecognizer(tapToDoTitleGesture)
-        toDoTitle.adjustsFontSizeToFitWidth = true
-        toDoTitle.isUserInteractionEnabled = true
-        self.toDoListTableViewCellDelegate?.setCellContents(self, toDoTitle)
     }
     
     @objc func tapToDoTitle(_ sender: UITapGestureRecognizer) {

--- a/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.swift
+++ b/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.swift
@@ -11,6 +11,8 @@ import UIKit
 class ToDoListTableViewCell: UITableViewCell {
 
     @IBOutlet weak var todoText: UILabel!
+    @IBOutlet weak var startDateTime: DatePickerKeyboard!
+    @IBOutlet weak var setStartDateTime: UIButton!
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.swift
+++ b/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.swift
@@ -8,21 +8,36 @@
 
 import UIKit
 
+protocol ToDoListTableViewCellDelegate {
+    // セル内容の設定
+    func setCellContents(_ cell: ToDoListTableViewCell, _ toDoTitle: UILabel)
+    // タスクの名前をタップした時の処理
+    func didTappedToDoTitle(_ cell: ToDoListTableViewCell)
+    // 「設定」ボタンタップ時の処理
+    func didTappedStartDateTimeButton(_ cell: ToDoListTableViewCell, _ startDateTime: DatePickerKeyboard)
+}
+
 class ToDoListTableViewCell: UITableViewCell {
 
-    @IBOutlet weak var todoText: UILabel!
-    @IBOutlet weak var startDateTime: DatePickerKeyboard!
-    @IBOutlet weak var setStartDateTime: UIButton!
+    @IBOutlet weak private var toDoTitle: UILabel!
+    @IBOutlet weak private var startDateTime: DatePickerKeyboard!
+    var toDoListTableViewCellDelegate: ToDoListTableViewCellDelegate?
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+        
+        let tapToDoTitleGesture: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.tapToDoTitle(_:)))
+        toDoTitle.addGestureRecognizer(tapToDoTitleGesture)
+        toDoTitle.adjustsFontSizeToFitWidth = true
+        toDoTitle.isUserInteractionEnabled = true
+        self.toDoListTableViewCellDelegate?.setCellContents(self, toDoTitle)
     }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
+    
+    @objc func tapToDoTitle(_ sender: UITapGestureRecognizer) {
+        self.toDoListTableViewCellDelegate?.didTappedToDoTitle(self)
     }
-
+    
+    @IBAction func tapStartDateTimeButton(_ sender: UIButton) {
+        self.toDoListTableViewCellDelegate?.didTappedStartDateTimeButton(self, startDateTime)
+    }
 }

--- a/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.xib
+++ b/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.xib
@@ -135,6 +135,8 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="setStartDateTime" destination="UQz-UL-dD8" id="8qE-j1-FFw"/>
+                <outlet property="startDateTime" destination="Wnt-jq-0qD" id="lJj-a0-EcY"/>
                 <outlet property="todoText" destination="A1W-wb-uJQ" id="b7H-NM-A1R"/>
             </connections>
             <point key="canvasLocation" x="116.8" y="84.107946026986511"/>

--- a/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.xib
+++ b/TodaysToDo/TodaysToDo/Views/ToDoListTableViewCell.xib
@@ -60,6 +60,9 @@
                                                 <color key="value" red="0.99515013100000005" green="0.75790410600000002" blue="0.36890478129999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="tapStartDateTimeButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="B8d-wZ-Nub"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
@@ -135,9 +138,8 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="setStartDateTime" destination="UQz-UL-dD8" id="8qE-j1-FFw"/>
                 <outlet property="startDateTime" destination="Wnt-jq-0qD" id="lJj-a0-EcY"/>
-                <outlet property="todoText" destination="A1W-wb-uJQ" id="b7H-NM-A1R"/>
+                <outlet property="toDoTitle" destination="A1W-wb-uJQ" id="29w-0H-Drl"/>
             </connections>
             <point key="canvasLocation" x="116.8" y="84.107946026986511"/>
         </tableViewCell>


### PR DESCRIPTION
# 概要
Inbox画面でタスクに対して開始日時を設定する機能を実装しました。

# 技術的変更点概要
- カスタムセルのボタンのアクションをViewControllerに追加する処理の追加。
- カスタムセルのViewにアクセスする処理の実装。
- そのセルのDatePickerの値を取得し、DBに設定する処理の実装。
- ModelのToDoクラスの`開始日時`の項目名を```startDate```から```startDateTime```へ変更。
- ModelのToDoクラスの`実行済み`の初期値を```true```から```false```へ変更。

# 参考URL
[TableViewCellにボタン付けていろいろやる](https://qiita.com/mzuk/items/0efc41460631c7c98c3c)

# 備考
なし